### PR TITLE
Fix Issue #31

### DIFF
--- a/SteamScout/Models/SessionStore.swift
+++ b/SteamScout/Models/SessionStore.swift
@@ -15,9 +15,9 @@ enum RequestType: Int {
     var url : String {
         switch(self) {
         case .eventList:
-            return "https://frc-api.firstinspires.org/v2.0/2016/events?exludeDistrict=false"
+            return "https://frc-api.firstinspires.org/v2.0/2017/events?exludeDistrict=false"
         case .scheduleList:
-            return "https://frc-api.firstinspires.org/v2.0/2016/schedule/\(ScheduleStore.sharedStore.currentSchedule!)?tournamentLevel=qual"
+            return "https://frc-api.firstinspires.org/v2.0/2017/schedule/\(ScheduleStore.sharedStore.currentSchedule!)?tournamentLevel=qual"
         default:
             return ""
         }


### PR DESCRIPTION
## Changes
- updated year in SessionStore API calls to 2017 instead of 2016
## Issue Fixed
- #31 

## Checks
- [x] App Builds and Runs
- [x] Event List is Retrievable
- [x] Selecting a Event allows option to get Schedule
- [x] Schedule is received and Build Lists can be created

