### PR TITLE
Fix Issue #28

### DIFF
--- a/SteamScout.xcodeproj/project.pbxproj
+++ b/SteamScout.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		C44A81321E35D33800BA367B /* SelectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44A812C1E35D33800BA367B /* SelectionButton.swift */; };
 		C44A81331E35D33800BA367B /* themeDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44A812D1E35D33800BA367B /* themeDefinitions.swift */; };
 		C48158AE1E7A449B0009A89B /* UINavigationController+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */; };
+		C48158B01E7A57090009A89B /* AppUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48158AF1E7A57090009A89B /* AppUtility.swift */; };
 		C4D61D2D1E35E39400320E1D /* SteamScoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D61D251E35E37C00320E1D /* SteamScoutTests.swift */; };
 		C4D61D2E1E35E39F00320E1D /* SteamScoutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D61D2A1E35E38100320E1D /* SteamScoutUITests.swift */; };
 		C4F889B01E5424BB00DC0826 /* StrongMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F889AF1E5424BB00DC0826 /* StrongMatch.swift */; };
@@ -117,6 +118,7 @@
 		C44A812C1E35D33800BA367B /* SelectionButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SelectionButton.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C44A812D1E35D33800BA367B /* themeDefinitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = themeDefinitions.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rotation.swift"; sourceTree = "<group>"; };
+		C48158AF1E7A57090009A89B /* AppUtility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppUtility.swift; sourceTree = "<group>"; };
 		C4D61D241E35E37C00320E1D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C4D61D251E35E37C00320E1D /* SteamScoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SteamScoutTests.swift; sourceTree = "<group>"; };
 		C4D61D291E35E38100320E1D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -280,6 +282,7 @@
 				C44A812C1E35D33800BA367B /* SelectionButton.swift */,
 				C44A812D1E35D33800BA367B /* themeDefinitions.swift */,
 				C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */,
+				C48158AF1E7A57090009A89B /* AppUtility.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				C44A811F1E35D32C00BA367B /* ResultsTeleopViewController.swift in Sources */,
 				C402A8E61E777A5B003817FF /* TeleopViewController.swift in Sources */,
 				C43EFFAD1E38270A00BC2BB9 /* MatchStore.swift in Sources */,
+				C48158B01E7A57090009A89B /* AppUtility.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SteamScout.xcodeproj/project.pbxproj
+++ b/SteamScout.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		C44A81311E35D33800BA367B /* ScheduleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44A812B1E35D33800BA367B /* ScheduleCell.swift */; };
 		C44A81321E35D33800BA367B /* SelectionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44A812C1E35D33800BA367B /* SelectionButton.swift */; };
 		C44A81331E35D33800BA367B /* themeDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C44A812D1E35D33800BA367B /* themeDefinitions.swift */; };
+		C48158AE1E7A449B0009A89B /* UINavigationController+Rotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */; };
 		C4D61D2D1E35E39400320E1D /* SteamScoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D61D251E35E37C00320E1D /* SteamScoutTests.swift */; };
 		C4D61D2E1E35E39F00320E1D /* SteamScoutUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D61D2A1E35E38100320E1D /* SteamScoutUITests.swift */; };
 		C4F889B01E5424BB00DC0826 /* StrongMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4F889AF1E5424BB00DC0826 /* StrongMatch.swift */; };
@@ -115,6 +116,7 @@
 		C44A812B1E35D33800BA367B /* ScheduleCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = ScheduleCell.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C44A812C1E35D33800BA367B /* SelectionButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = SelectionButton.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		C44A812D1E35D33800BA367B /* themeDefinitions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = themeDefinitions.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UINavigationController+Rotation.swift"; sourceTree = "<group>"; };
 		C4D61D241E35E37C00320E1D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C4D61D251E35E37C00320E1D /* SteamScoutTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SteamScoutTests.swift; sourceTree = "<group>"; };
 		C4D61D291E35E38100320E1D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -264,9 +266,6 @@
 				C44A81211E35D33100BA367B /* MasterViewController.swift */,
 				C44A81221E35D33100BA367B /* ScheduleViewController.swift */,
 				C44A81231E35D33100BA367B /* ToolsViewController.swift */,
-				C02BCF7C1E52A045000E3CD2 /* TeleopViewController.swift */,
-				C006845F1E52A2A300C8F009 /* AutonomousViewController.swift */,
-				C032AFA81E55386400EC797C /* PenaltyViewController.swift */,
 			);
 			path = MasterControllers;
 			sourceTree = "<group>";
@@ -280,6 +279,7 @@
 				C44A812B1E35D33800BA367B /* ScheduleCell.swift */,
 				C44A812C1E35D33800BA367B /* SelectionButton.swift */,
 				C44A812D1E35D33800BA367B /* themeDefinitions.swift */,
+				C48158AD1E7A449B0009A89B /* UINavigationController+Rotation.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -512,6 +512,7 @@
 				C402A8ED1E77ABB8003817FF /* SteamGearPlacementType.swift in Sources */,
 				C44A81191E35D32C00BA367B /* FinalViewController.swift in Sources */,
 				C44A81261E35D33100BA367B /* ToolsViewController.swift in Sources */,
+				C48158AE1E7A449B0009A89B /* UINavigationController+Rotation.swift in Sources */,
 				C44A811D1E35D32C00BA367B /* ResultsMatchInfoViewController.swift in Sources */,
 				C44A80D61E356EBA00BA367B /* DetailViewController.swift in Sources */,
 				C44A810C1E35D32500BA367B /* Event.swift in Sources */,

--- a/SteamScout/AppDelegate.swift
+++ b/SteamScout/AppDelegate.swift
@@ -12,6 +12,7 @@ import UIKit
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate {
 
     var window: UIWindow?
+    var orientationLock: UIInterfaceOrientationMask = .all
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
@@ -24,21 +25,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         
-        if let vc = window?.rootViewController?.presentedViewController as? AutonomousViewController {
-            if vc.isBeingPresented {
-                return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
-            } else {
-                return UIInterfaceOrientationMask.all
-            }
-        } else if let vc = window?.rootViewController?.presentedViewController as? TeleopViewController {
-            if vc.isBeingPresented {
-                return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
-            } else {
-                return UIInterfaceOrientationMask.all
-            }
-        }
-        
-        return UIInterfaceOrientationMask.all
+        return orientationLock
     }
     
     func applicationWillResignActive(_ application: UIApplication) {

--- a/SteamScout/AppDelegate.swift
+++ b/SteamScout/AppDelegate.swift
@@ -13,7 +13,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
 
     var window: UIWindow?
 
-
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         let splitViewController = self.window!.rootViewController as! UISplitViewController
@@ -22,7 +21,26 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         splitViewController.delegate = self
         return true
     }
-
+    
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        
+        if let vc = window?.rootViewController?.presentedViewController as? AutonomousViewController {
+            if vc.isBeingPresented {
+                return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+            } else {
+                return UIInterfaceOrientationMask.all
+            }
+        } else if let vc = window?.rootViewController?.presentedViewController as? TeleopViewController {
+            if vc.isBeingPresented {
+                return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+            } else {
+                return UIInterfaceOrientationMask.all
+            }
+        }
+        
+        return UIInterfaceOrientationMask.all
+    }
+    
     func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
@@ -58,4 +76,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     }
 
 }
-

--- a/SteamScout/Base.lproj/Main.storyboard
+++ b/SteamScout/Base.lproj/Main.storyboard
@@ -967,7 +967,7 @@
                         <barButtonItem key="rightBarButtonItem" title="Next" id="RMV-Zh-vGD">
                             <connections>
                                 <action selector="nextButtonTap:" destination="svD-E9-SOG" id="N2m-A7-7Pb"/>
-                                <segue destination="uFr-9Y-zqS" kind="presentation" modalPresentationStyle="fullScreen" id="la2-Tc-j94"/>
+                                <segue destination="uFr-9Y-zqS" kind="presentation" modalPresentationStyle="overFullScreen" id="la2-Tc-j94"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>

--- a/SteamScout/Base.lproj/Main.storyboard
+++ b/SteamScout/Base.lproj/Main.storyboard
@@ -752,7 +752,7 @@
                                 <rect key="frame" x="0.0" y="28" width="768" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LAp-cY-foD" id="xIV-Nq-258">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="79.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="79"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="2Kv-8V-mP0">
@@ -858,20 +858,20 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="k1c-N9-eiA">
-                                <rect key="frame" x="20" y="20" width="728" height="549.5"/>
+                                <rect key="frame" x="20" y="20" width="728" height="876"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="I0X-aD-wGD">
-                                        <rect key="frame" x="0.0" y="0.0" width="728" height="131.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="728" height="213"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Team    Number:" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nE1-zT-Lo8">
-                                                <rect key="frame" x="0.0" y="0.0" width="243" height="131.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="213"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="UVR-1u-hWS">
-                                                <rect key="frame" x="243" y="0.0" width="485" height="131.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                <rect key="frame" x="243" y="0.0" width="485" height="213"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 <connections>
                                                     <action selector="textFieldEditDidEnd:" destination="svD-E9-SOG" eventType="editingDidEnd" id="pA2-iI-u15"/>
@@ -880,17 +880,17 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Jhc-T5-uqC">
-                                        <rect key="frame" x="0.0" y="139.5" width="728" height="131.5"/>
+                                        <rect key="frame" x="0.0" y="221" width="728" height="213"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Match  Number:" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ioQ-2q-BqY">
-                                                <rect key="frame" x="0.0" y="0.0" width="243" height="131.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="213"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="tAZ-E8-IOX">
-                                                <rect key="frame" x="243" y="0.0" width="485" height="131.5"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="22"/>
+                                                <rect key="frame" x="243" y="0.0" width="485" height="213"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                                 <connections>
                                                     <action selector="textFieldEditDidEnd:" destination="svD-E9-SOG" eventType="editingDidEnd" id="YmF-Ut-Y9A"/>
@@ -899,16 +899,16 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EoA-Nn-GTR">
-                                        <rect key="frame" x="0.0" y="279" width="728" height="131"/>
+                                        <rect key="frame" x="0.0" y="442" width="728" height="213"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Alliance:" textAlignment="center" lineBreakMode="characterWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LVL-sd-nhL">
-                                                <rect key="frame" x="0.0" y="0.0" width="243" height="131"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="243" height="213"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Su6-xF-eGH" customClass="SelectionButton" customModule="SteamScout" customModuleProvider="target">
-                                                <rect key="frame" x="243" y="0.0" width="242.5" height="131"/>
+                                                <rect key="frame" x="243" y="0.0" width="242.5" height="213"/>
                                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Blue">
                                                     <color key="titleColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -918,7 +918,7 @@
                                                 </connections>
                                             </button>
                                             <button opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cf7-ZV-QRV" customClass="SelectionButton" customModule="SteamScout" customModuleProvider="target">
-                                                <rect key="frame" x="485.5" y="0.0" width="242.5" height="131"/>
+                                                <rect key="frame" x="485.5" y="0.0" width="242.5" height="213"/>
                                                 <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <state key="normal" title="Red">
                                                     <color key="titleColor" red="1" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -934,7 +934,7 @@
                                         </constraints>
                                     </stackView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="C1M-YW-pqb" customClass="SelectionButton" customModule="SteamScout" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="418" width="728" height="131.5"/>
+                                        <rect key="frame" x="0.0" y="663" width="728" height="213"/>
                                         <color key="tintColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <state key="normal" title="No Show">
                                             <color key="titleColor" red="1" green="0.50196081400000003" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -955,7 +955,7 @@
                             <constraint firstItem="k1c-N9-eiA" firstAttribute="top" secondItem="Z5k-ZS-6pw" secondAttribute="bottom" constant="20" id="0Lz-vf-HuF"/>
                             <constraint firstItem="k1c-N9-eiA" firstAttribute="centerX" secondItem="tCZ-06-TGi" secondAttribute="centerX" id="G0K-Lg-LrN"/>
                             <constraint firstItem="k1c-N9-eiA" firstAttribute="leading" secondItem="tCZ-06-TGi" secondAttribute="leadingMargin" id="Uxd-Uc-r11"/>
-                            <constraint firstItem="k1c-N9-eiA" firstAttribute="height" secondItem="tCZ-06-TGi" secondAttribute="height" multiplier="0.6" id="ra9-8q-YLA"/>
+                            <constraint firstItem="k1c-N9-eiA" firstAttribute="centerY" secondItem="tCZ-06-TGi" secondAttribute="centerY" id="idd-9o-H05"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Team Info" id="aqy-50-pZt">
@@ -967,7 +967,7 @@
                         <barButtonItem key="rightBarButtonItem" title="Next" id="RMV-Zh-vGD">
                             <connections>
                                 <action selector="nextButtonTap:" destination="svD-E9-SOG" id="N2m-A7-7Pb"/>
-                                <segue destination="uFr-9Y-zqS" kind="presentation" id="la2-Tc-j94"/>
+                                <segue destination="uFr-9Y-zqS" kind="presentation" modalPresentationStyle="fullScreen" id="la2-Tc-j94"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
@@ -1012,7 +1012,7 @@
                                 <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2Ro-38-DKu" id="Osa-2W-v4O">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="O8L-25-6lc">
@@ -1510,8 +1510,6 @@
                         </barButtonItem>
                     </navigationItem>
                     <simulatedToolbarMetrics key="simulatedBottomBarMetrics"/>
-                    <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-                    <size key="freeformSize" width="768" height="1024"/>
                     <connections>
                         <outlet property="BaselineCrossed" destination="gUP-vo-ihz" id="VL2-3X-uJ0"/>
                         <outlet property="HighGoalSlider" destination="DhQ-5G-dwq" id="KOn-S6-XtP"/>
@@ -1733,7 +1731,7 @@
                                 <rect key="frame" x="0.0" y="28" width="768" height="62"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cfM-2p-V79" id="qgg-bZ-X2m">
-                                    <rect key="frame" x="0.0" y="0.0" width="768" height="61.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="61"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-3b-OMF">
@@ -1937,9 +1935,9 @@
         <image name="Gear" width="767" height="750"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="pMA-Qb-jdF"/>
         <segue reference="J5x-uL-Uxx"/>
-        <segue reference="xU2-D7-M6L"/>
+        <segue reference="pMA-Qb-jdF"/>
+        <segue reference="g4S-49-J8N"/>
     </inferredMetricsTieBreakers>
     <color key="tintColor" red="0.99810189008712769" green="0.41443628072738647" blue="0.0016002511838451028" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
 </document>

--- a/SteamScout/DetailControllers/DataEntry/AutonomousViewController.swift
+++ b/SteamScout/DetailControllers/DataEntry/AutonomousViewController.swift
@@ -137,6 +137,18 @@ class AutonomousViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    override var shouldAutorotate: Bool {
+        return true
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+    }
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return .portrait
+    }
+    
     // MARK: - Navigation
 
     // In a storyboard-based application, you will often want to do a little preparation before navigation

--- a/SteamScout/DetailControllers/DataEntry/AutonomousViewController.swift
+++ b/SteamScout/DetailControllers/DataEntry/AutonomousViewController.swift
@@ -93,6 +93,8 @@ class AutonomousViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
+        AppUtility.lockOrientation(to: .portrait)
+        
         // Get a reference to the current match
         match = MatchStore.sharedStore.currentMatch as! SteamMatch
         
@@ -142,9 +144,9 @@ class AutonomousViewController: UIViewController {
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+        return UIInterfaceOrientationMask.portrait
     }
-    
+
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
         return .portrait
     }

--- a/SteamScout/DetailControllers/DataEntry/PenaltyViewController.swift
+++ b/SteamScout/DetailControllers/DataEntry/PenaltyViewController.swift
@@ -83,7 +83,6 @@ class PenaltyViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
-
     /*
     // MARK: - Navigation
 

--- a/SteamScout/DetailControllers/DataEntry/TeleopViewController.swift
+++ b/SteamScout/DetailControllers/DataEntry/TeleopViewController.swift
@@ -55,7 +55,7 @@ class TeleopViewController: UIViewController {
     }
     
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+        return UIInterfaceOrientationMask.portrait
     }
     
     override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {

--- a/SteamScout/DetailControllers/DataEntry/TeleopViewController.swift
+++ b/SteamScout/DetailControllers/DataEntry/TeleopViewController.swift
@@ -50,6 +50,17 @@ class TeleopViewController: UIViewController {
         // Dispose of any resources that can be recreated.
     }
     
+    override var shouldAutorotate: Bool {
+        return true
+    }
+    
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait.union(.portraitUpsideDown)
+    }
+    
+    override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return .portrait
+    }
 
     // MARK: - Navigation
 

--- a/SteamScout/Info.plist
+++ b/SteamScout/Info.plist
@@ -32,6 +32,8 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<true/>
 	<key>UIStatusBarTintParameters</key>
 	<dict>
 		<key>UINavigationBar</key>

--- a/SteamScout/Info.plist
+++ b/SteamScout/Info.plist
@@ -52,8 +52,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/SteamScout/Info.plist
+++ b/SteamScout/Info.plist
@@ -51,7 +51,6 @@
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>

--- a/SteamScout/MasterControllers/MasterViewController.swift
+++ b/SteamScout/MasterControllers/MasterViewController.swift
@@ -72,6 +72,7 @@ class MasterViewController: UITableViewController {
     // MARK: Unwind Segues
     
     @IBAction func unwindToMatchView(_ sender:UIStoryboardSegue) {
+        AppUtility.unlockOrientation()
         self.tableView.reloadData()
     }
     

--- a/SteamScout/Support/AppUtility.swift
+++ b/SteamScout/Support/AppUtility.swift
@@ -1,0 +1,21 @@
+//
+//  AppUtility.swift
+//  SteamScout
+//
+//  Created by Srinivas Dhanwada on 3/16/17.
+//  Copyright © 2017 dhanwada. All rights reserved.
+//
+
+import UIKit
+
+struct AppUtility {
+    static func lockOrientation(to orientation: UIInterfaceOrientationMask) {
+        if let delegate = UIApplication.shared.delegate as? AppDelegate {
+            delegate.orientationLock = orientation
+        }
+    }
+    
+    static func unlockOrientation() {
+        lockOrientation(to: .all)
+    }
+}

--- a/SteamScout/Support/CustomContainerArrayView.swift
+++ b/SteamScout/Support/CustomContainerArrayView.swift
@@ -64,6 +64,14 @@ class CustomContainerArrayView: UIViewController {
         if viewData.count <= 0 {
             setupViewDataArray()
         }
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(CustomContainerArrayView.orientationChange), name: NSNotification.Name.UIDeviceOrientationDidChange, object: nil)
+    }
+    
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        
+        NotificationCenter.default.removeObserver(self)
     }
     
     func setupViewDataArray() {
@@ -175,6 +183,19 @@ class CustomContainerArrayView: UIViewController {
                     }
                 }
             })
+        }
+    }
+    
+    func orientationChange() {
+        for i in 0..<self.viewData.count {
+            let y = self.viewData[i].nc.navigationBar.frame.height * CGFloat(i);
+            let width = self.view.bounds.width
+            let height = self.view.bounds.height - (self.viewData[i].nc.navigationBar.frame.height * CGFloat(self.views.count - 1))
+            let frame = CGRect(x: 0, y: y, width: width, height: height)
+            self.viewData[i].nc.view.frame = frame
+            self.viewData[i].highCenter = self.viewData[i].nc.view.center
+            self.viewData[i].lowCenter = CGPoint(x: self.viewData[i].highCenter.x, y: self.viewData[i].highCenter.y + self.viewData[i].nc.view.frame.height - self.viewData[i].nc.navigationBar.frame.height)
+            self.viewData[i].nc.view.center = self.viewData[i].centerForViewPos()
         }
     }
 }

--- a/SteamScout/Support/UINavigationController+Rotation.swift
+++ b/SteamScout/Support/UINavigationController+Rotation.swift
@@ -1,0 +1,23 @@
+//
+//  UINavigationController+Rotation.swift
+//  SteamScout
+//
+//  Created by Srinivas Dhanwada on 3/15/17.
+//  Copyright © 2017 dhanwada. All rights reserved.
+//
+
+import UIKit
+
+extension UINavigationController {
+    open override var shouldAutorotate: Bool {
+        return visibleViewController?.shouldAutorotate ?? true
+    }
+    
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+       return visibleViewController?.supportedInterfaceOrientations ?? .all
+    }
+    
+    open override var preferredInterfaceOrientationForPresentation: UIInterfaceOrientation {
+        return visibleViewController?.preferredInterfaceOrientationForPresentation ?? .portrait
+    }
+}


### PR DESCRIPTION
## Changes
- When entering Match Data, the app is restricted to portrait mode
- When viewing results/schedule/events, rotation is not restricted
- Fixed bug where rotating the results view would not render correctly

## Issue Fixed
- #28 

## Checks
- [x] App Builds and Runs
- [x] Rotating the device works outside of data entry
- [x] Rotating the device does not work inside of data entry
- [x] Data entry forces portrait mode
- [x] Results view does not get messed up when rotating
