### PR TITLE
Save Match Data on Clear

### DIFF
--- a/SteamScout/Models/Match/MatchStore.swift
+++ b/SteamScout/Models/Match/MatchStore.swift
@@ -90,7 +90,11 @@ class MatchStore: AnyObject {
         
         let csvDataSave = writeCSVFile(withType: type)
         
-        return (matchDataSave ? 1 : 0) + (queueDataSave ? 2 : 0) + (csvDataSave ? 4 : 0)
+        let status = (matchDataSave ? 1 : 0) + (queueDataSave ? 2 : 0) + (csvDataSave ? 4 : 0)
+        
+        print("save returning \(status)")
+        
+        return status
     }
     
     func saveMatchQueueData() -> Bool {
@@ -266,10 +270,12 @@ class MatchStore: AnyObject {
     func clearMatchData(_ type:Int) {
         if type & 1 == 1 {
             matchesToScout.removeAll()
+            saveMatchQueueData()
         }
         
         if type & 2 == 2 {
             allMatches.removeAll()
+            saveMatchData()
         }
     }
 }


### PR DESCRIPTION
## Changes
- Save the match data when a clear occurs

## Issue Fixed
- #89

## Checks
- [x] App builds and runs
- [x] Clearing data removes it and the data no longer persists when the app quits

![issue_89_fixed](https://user-images.githubusercontent.com/2002470/27166041-9c0a170a-515d-11e7-8250-715ef543f568.gif)
