### PR TITLE
Handle faulty UX state logic

### DIFF
--- a/SteamScout/Base.lproj/MasterViews.storyboard
+++ b/SteamScout/Base.lproj/MasterViews.storyboard
@@ -48,7 +48,7 @@
                                 <rect key="frame" x="0.0" y="28" width="540" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="LAp-cY-foD" id="xIV-Nq-258">
-                                    <rect key="frame" x="0.0" y="0.0" width="540" height="79"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="540" height="79.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="2Kv-8V-mP0">
@@ -162,7 +162,7 @@
                                 <rect key="frame" x="0.0" y="22" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2Ro-38-DKu" id="Osa-2W-v4O">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="O8L-25-6lc">
@@ -257,6 +257,8 @@
                     </navigationItem>
                     <connections>
                         <outlet property="clearExportButton" destination="zzq-lg-ULG" id="Ggt-Of-sdd"/>
+                        <outlet property="showScheduleButton" destination="YWd-SN-x6N" id="8j6-m3-7CK"/>
+                        <outlet property="showToolsButton" destination="Ulf-7V-RQa" id="giF-Bl-BdX"/>
                         <segue destination="kJb-XC-gky" kind="showDetail" identifier="showMatchSummary" id="DsS-sV-Hyu"/>
                         <segue destination="EYX-f4-dmc" kind="popoverPresentation" identifier="segueToMatchQueue" popoverAnchorBarButtonItem="rt0-FK-LlX" id="FE0-HP-URS">
                             <popoverArrowDirection key="popoverArrowDirection" up="YES" down="YES" left="YES" right="YES"/>
@@ -465,7 +467,7 @@
                                 <rect key="frame" x="0.0" y="28" width="320" height="62"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="cfM-2p-V79" id="qgg-bZ-X2m">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="61"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="61.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="ydv-3b-OMF">

--- a/SteamScout/MasterControllers/MasterViewController.swift
+++ b/SteamScout/MasterControllers/MasterViewController.swift
@@ -12,6 +12,8 @@ import MBProgressHUD
 class MasterViewController: UITableViewController {
     
     @IBOutlet var clearExportButton:UIBarButtonItem!
+    @IBOutlet var showScheduleButton:UIBarButtonItem!
+    @IBOutlet var showToolsButton:UIBarButtonItem!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -91,6 +93,8 @@ class MasterViewController: UITableViewController {
     }
     
     @IBAction func handleExportOrClear(_ sender:UIBarButtonItem) {
+        showScheduleButton.isEnabled = false
+        showToolsButton.isEnabled = false
         if self.isEditing {
             handleClear(sender)
         } else {
@@ -117,6 +121,7 @@ class MasterViewController: UITableViewController {
         
         ac.popoverPresentationController?.barButtonItem = sender
         ac.popoverPresentationController?.sourceView = self.view
+        ac.popoverPresentationController?.delegate = self
         
         ac.view.layoutIfNeeded()
         self.present(ac, animated: true, completion: nil)
@@ -169,6 +174,7 @@ class MasterViewController: UITableViewController {
 
         ac.popoverPresentationController?.barButtonItem = sender
         ac.popoverPresentationController?.sourceView = self.view
+        ac.popoverPresentationController?.delegate = self
         
         ac.view.layoutIfNeeded()
         self.present(ac, animated: true, completion: nil)
@@ -305,6 +311,9 @@ extension MasterViewController: UIPopoverPresentationControllerDelegate {
             if let _ = nc.topViewController as? TeamInfoViewController {
                 MatchStore.sharedStore.cancelCurrentMatchEdit()
             }
+        } else if popoverPresentationController.presentedViewController is UIAlertController {
+            showToolsButton.isEnabled = true
+            showScheduleButton.isEnabled = true
         }
     }
 }


### PR DESCRIPTION
## Changes
- The schedule and tools `UIBarButtonItem` now are referenced as IBOutlets with the `MasterViewController`
- The buttons are disabled and reenabled manually based on the correct events.

## Issue Fixed
- #88

## Checks
- [x] App builds and runs
- [x] UX state logic is fixed

![issue_88_fixed](https://user-images.githubusercontent.com/2002470/27166577-6417ad18-5161-11e7-9359-286655e4ab25.gif)


